### PR TITLE
fix non_type_as_type_argument for Uint8List

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:fast_contacts/fast_contacts.dart';
 import 'package:flutter/material.dart';

--- a/lib/src/fast_contacts.dart
+++ b/lib/src/fast_contacts.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:fast_contacts/fast_contacts.dart';
 import 'package:flutter/foundation.dart';


### PR DESCRIPTION
On flutter 3.0.5 the application does not start due to the fact that Uint8List is not imported
* fix non_type_as_type_argument for Uint8List
